### PR TITLE
issue with manual search with imdb id

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -240,9 +240,14 @@ class PlexMovieAgent(Agent.Movies):
         else:
           id = tmdb_dict['id']
 
+        if tmdb_dict['release_date'].split('-'):
+          year = tmdb_dict['release_date'].split('-')[0]
+        else:
+          year = ''
+
         result = MetadataSearchResult(id=id,
                                       name=tmdb_dict['title'],
-                                      year=int(tmdb_dict['release_date'].split('-')[0]),
+                                      year=year,
                                       score=100,
                                       lang=lang)
         Log(result)


### PR DESCRIPTION
I had an issue with manual search with imdb id (ex. tt4988692). This addition fixes the issue. (freebsd and with plexpass) 

exception: 
…line 232, in perform_tmdb_movie_search
    year=int(tmdb_dict['release_date'].split('-')[0]),
ValueError: invalid literal for int() with base 10: ''